### PR TITLE
feat(config): warn when permission-rule keys are placed in extension config.json

### DIFF
--- a/src/extension-config.ts
+++ b/src/extension-config.ts
@@ -61,6 +61,49 @@ function createDefaultConfigContent(): string {
   return `${JSON.stringify(DEFAULT_EXTENSION_CONFIG, null, 2)}\n`;
 }
 
+const PERMISSION_RULE_KEYS = [
+  "defaultPolicy",
+  "tools",
+  "bash",
+  "mcp",
+  "skills",
+  "special",
+  "external_directory",
+  "doom_loop",
+] as const;
+
+const KNOWN_EXTENSION_CONFIG_KEYS = new Set([
+  "debugLog",
+  "permissionReviewLog",
+  "yoloMode",
+]);
+
+export function detectMisplacedPermissionKeys(raw: unknown): string[] {
+  const record = toRecord(raw);
+  const present: string[] = [];
+  for (const key of PERMISSION_RULE_KEYS) {
+    if (
+      Object.prototype.hasOwnProperty.call(record, key) &&
+      !KNOWN_EXTENSION_CONFIG_KEYS.has(key)
+    ) {
+      present.push(key);
+    }
+  }
+  return present;
+}
+
+export function buildMisplacedKeysWarning(
+  configPath: string,
+  keys: readonly string[],
+): string {
+  const formatted = keys.map((key) => `'${key}'`).join(", ");
+  return (
+    `pi-permission-system: '${configPath}' contains permission-rule keys that this file does not honor: ${formatted}. ` +
+    "This file only configures extension settings (debugLog, permissionReviewLog, yoloMode). " +
+    "Move permission rules to '~/.pi/agent/pi-permissions.jsonc' (global), '<project>/.pi/agent/pi-permissions.jsonc' (project), or an agent's frontmatter."
+  );
+}
+
 export function normalizePermissionSystemConfig(
   raw: unknown,
 ): PermissionSystemExtensionConfig {
@@ -106,10 +149,15 @@ export function loadPermissionSystemConfig(
     const raw = readFileSync(configPath, "utf-8");
     const parsed = JSON.parse(raw) as unknown;
     const config = normalizePermissionSystemConfig(parsed);
+    const misplaced = detectMisplacedPermissionKeys(parsed);
+    const misplacedWarning =
+      misplaced.length > 0
+        ? buildMisplacedKeysWarning(configPath, misplaced)
+        : undefined;
     return {
       config,
       created: ensureResult.created,
-      warning: ensureResult.warning,
+      warning: ensureResult.warning ?? misplacedWarning,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/tests/permission-system.test.ts
+++ b/tests/permission-system.test.ts
@@ -338,6 +338,72 @@ test("Permission-system extension config normalizes invalid persisted values bac
   }
 });
 
+test("Permission-system extension config warns when permission-rule keys are placed in extension config.json", () => {
+  const baseDir = mkdtempSync(
+    join(tmpdir(), "pi-permission-system-config-misplaced-"),
+  );
+  const configPath = join(baseDir, "config.json");
+
+  try {
+    writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          debugLog: false,
+          permissionReviewLog: true,
+          yoloMode: false,
+          defaultPolicy: { bash: "ask" },
+          tools: { read: "allow" },
+          bash: { "git status": "allow" },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const result = loadPermissionSystemConfig(configPath);
+    assert.equal(result.created, false);
+    assert.deepEqual(result.config, DEFAULT_EXTENSION_CONFIG);
+    assert.notEqual(result.warning, undefined);
+    const warning = result.warning ?? "";
+    assert.match(warning, /'defaultPolicy'/);
+    assert.match(warning, /'tools'/);
+    assert.match(warning, /'bash'/);
+    assert.match(warning, /pi-permissions\.jsonc/);
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});
+
+test("Permission-system extension config does not warn when only known keys are present", () => {
+  const baseDir = mkdtempSync(
+    join(tmpdir(), "pi-permission-system-config-clean-"),
+  );
+  const configPath = join(baseDir, "config.json");
+
+  try {
+    writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          debugLog: true,
+          permissionReviewLog: true,
+          yoloMode: false,
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const result = loadPermissionSystemConfig(configPath);
+    assert.equal(result.warning, undefined);
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});
+
 test("Permission-system extension config save persists normalized config", () => {
   const baseDir = mkdtempSync(
     join(tmpdir(), "pi-permission-system-config-save-"),


### PR DESCRIPTION
Fixes #4.

Pasting a permission policy into `<extension-root>/config.json` is an easy mistake: the file already holds extension settings, but only three booleans are honored there and everything else is silently dropped.

Detect permission-rule keys (`defaultPolicy`, `tools`, `bash`, `mcp`, `skills`, `special`, `external_directory`, `doom_loop`) at load time and surface a warning through the existing `result.warning` channel pointing the user at the right files.

Tests cover both the warning path and the no-warning path.