### PR TITLE
feat(logging): emit resolved config paths at session start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1544,6 +1544,17 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     return toolPermission !== "deny";
   };
 
+  const reportResolvedConfigPaths = (cwd: string | null | undefined): void => {
+    const paths = permissionManager.getResolvedConfigPaths();
+    const details: Record<string, unknown> = {
+      cwd: cwd ?? null,
+      extensionConfigPath: getPermissionSystemConfigPath(),
+      ...paths,
+    };
+    writeReviewLog("config.resolved", details);
+    writeDebugLog("config.resolved", details);
+  };
+
   pi.on("session_start", async (event, ctx) => {
     runtimeContext = ctx;
     refreshExtensionConfig(ctx);
@@ -1551,6 +1562,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     invalidateAgentStartCache();
     lastKnownActiveAgentName = getActiveAgentName(ctx);
     startForwardedPermissionPolling(ctx);
+    reportResolvedConfigPaths(ctx.cwd);
 
     if (event.reason === "reload") {
       writeDebugLog("lifecycle.reload", {
@@ -1568,6 +1580,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     invalidateAgentStartCache();
     lastKnownActiveAgentName = getActiveAgentName(ctx);
     startForwardedPermissionPolling(ctx);
+    reportResolvedConfigPaths(ctx.cwd);
   });
 
   pi.on("resources_discover", async (event, _ctx) => {

--- a/src/permission-manager.ts
+++ b/src/permission-manager.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
 
@@ -755,6 +755,38 @@ export class PermissionManager {
 
     this.resolvedPermissionsCache.set(cacheKey, { stamp, value });
     return value;
+  }
+
+  getResolvedConfigPaths(): {
+    globalConfigPath: string;
+    globalConfigExists: boolean;
+    projectGlobalConfigPath: string | null;
+    projectGlobalConfigExists: boolean;
+    agentsDir: string;
+    agentsDirExists: boolean;
+    projectAgentsDir: string | null;
+    projectAgentsDirExists: boolean;
+    legacyGlobalSettingsPath: string;
+    legacyGlobalSettingsExists: boolean;
+    globalMcpConfigPath: string;
+    globalMcpConfigExists: boolean;
+  } {
+    const exists = (path: string | null): boolean =>
+      path !== null && existsSync(path);
+    return {
+      globalConfigPath: this.globalConfigPath,
+      globalConfigExists: exists(this.globalConfigPath),
+      projectGlobalConfigPath: this.projectGlobalConfigPath,
+      projectGlobalConfigExists: exists(this.projectGlobalConfigPath),
+      agentsDir: this.agentsDir,
+      agentsDirExists: exists(this.agentsDir),
+      projectAgentsDir: this.projectAgentsDir,
+      projectAgentsDirExists: exists(this.projectAgentsDir),
+      legacyGlobalSettingsPath: this.legacyGlobalSettingsPath,
+      legacyGlobalSettingsExists: exists(this.legacyGlobalSettingsPath),
+      globalMcpConfigPath: this.globalMcpConfigPath,
+      globalMcpConfigExists: exists(this.globalMcpConfigPath),
+    };
   }
 
   getBashPermissions(agentName?: string): BashPermissions {

--- a/tests/permission-system.test.ts
+++ b/tests/permission-system.test.ts
@@ -1788,6 +1788,61 @@ test("PermissionManager reads config from PI_CODING_AGENT_DIR when set", () => {
   }
 });
 
+test("PermissionManager.getResolvedConfigPaths reports each resolved path and whether it exists", () => {
+  const baseDir = mkdtempSync(
+    join(tmpdir(), "pi-permission-system-resolved-paths-"),
+  );
+  const projectRoot = join(baseDir, "project", ".pi", "agent");
+  const agentsDir = join(baseDir, "agents");
+  const projectAgentsDir = join(projectRoot, "agents");
+  const globalConfigPath = join(baseDir, "pi-permissions.jsonc");
+  const projectConfigPath = join(projectRoot, "pi-permissions.jsonc");
+  const legacyPath = join(baseDir, "settings.json");
+  const mcpPath = join(baseDir, "mcp.json");
+
+  mkdirSync(agentsDir, { recursive: true });
+  mkdirSync(projectAgentsDir, { recursive: true });
+  writeFileSync(globalConfigPath, "{}", "utf8");
+  // Intentionally do not create the project config file or legacy/mcp files
+  // so the existence flags are mixed.
+
+  try {
+    const manager = new PermissionManager({
+      globalConfigPath,
+      agentsDir,
+      projectGlobalConfigPath: projectConfigPath,
+      projectAgentsDir,
+      legacyGlobalSettingsPath: legacyPath,
+      globalMcpConfigPath: mcpPath,
+    });
+
+    const paths = manager.getResolvedConfigPaths();
+    assert.equal(paths.globalConfigPath, globalConfigPath);
+    assert.equal(paths.globalConfigExists, true);
+    assert.equal(paths.projectGlobalConfigPath, projectConfigPath);
+    assert.equal(paths.projectGlobalConfigExists, false);
+    assert.equal(paths.agentsDir, agentsDir);
+    assert.equal(paths.agentsDirExists, true);
+    assert.equal(paths.projectAgentsDir, projectAgentsDir);
+    assert.equal(paths.projectAgentsDirExists, true);
+    assert.equal(paths.legacyGlobalSettingsPath, legacyPath);
+    assert.equal(paths.legacyGlobalSettingsExists, false);
+    assert.equal(paths.globalMcpConfigPath, mcpPath);
+    assert.equal(paths.globalMcpConfigExists, false);
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});
+
+test("PermissionManager.getResolvedConfigPaths reports null project paths when none provided", () => {
+  const manager = new PermissionManager();
+  const paths = manager.getResolvedConfigPaths();
+  assert.equal(paths.projectGlobalConfigPath, null);
+  assert.equal(paths.projectGlobalConfigExists, false);
+  assert.equal(paths.projectAgentsDir, null);
+  assert.equal(paths.projectAgentsDirExists, false);
+});
+
 // ---------------------------------------------------------------------------
 // Skill prompt sanitization - multi-block regression tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #6.

Adds a `config.resolved` entry to the review log (and debug log) at every `session_start` listing the resolved paths for the extension config, global/project `pi-permissions.jsonc`, agents directories, legacy settings, and MCP config — plus whether each exists.

`PermissionManager.getResolvedConfigPaths()` returns the structured info; the extension logs it from the session_start handler.