### PR TITLE
feat: session-directory fallback for parent-session resolution

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -407,9 +407,30 @@ A session-directory path-based fallback (child session dir is nested under `suba
 ### Parent-session resolution (`SUBAGENT_PARENT_SESSION_ENV_CANDIDATES`)
 
 `resolvePermissionForwardingTargetSessionId()` iterates `SUBAGENT_PARENT_SESSION_ENV_CANDIDATES` and returns the first non-empty, non-`"unknown"` value.
-Currently only `PI_AGENT_ROUTER_PARENT_SESSION_ID` is in the list.
-Neither nicobailon nor HazAT sets a parent-session env var today, so forwarding still fails for those extensions with an explicit log message pointing to #98.
+The list contains `PI_AGENT_ROUTER_PARENT_SESSION_ID` (original `pi-agent-router`) and `PI_SUBAGENT_PARENT_SESSION` (shared convention for CLI-based subagent extensions).
 Adding a new env var candidate when an extension adopts the convention is a one-line change to the array.
+
+### Parent-session resolution (session-directory fallback)
+
+When every env candidate is empty or `"unknown"`, `resolvePermissionForwardingTargetSessionId()` falls back to `resolveParentSessionIdFromSessionDir()` in `src/parent-session-discovery.ts`.
+This covers CLI-based subagent extensions (`nicobailon/pi-subagents`, `HazAT/pi-interactive-subagents`) that do not yet set `PI_SUBAGENT_PARENT_SESSION` in spawned children — no upstream coordination is required.
+
+The helper relies on Pi's session-directory layout:
+
+```text
+<sessionsDir>/
+  <parentBaseName>.jsonl              ← parent session log; first line is { type: "session", id: <parentId> }
+  <parentBaseName>/
+    <runId>/run-<n>/                  ← child session directory (returned by ctx.sessionManager.getSessionDir())
+      session.jsonl                   ← child session log
+```
+
+This nesting is enforced by `nicobailon/pi-subagents` (`getSubagentSessionRoot()`) and is the same shape Pi's own `SessionManager` creates.
+The helper climbs at most `MAX_WALK_DEPTH` levels (currently 8), and at each level checks whether `<currentDir>.jsonl` exists as a sibling file.
+The first such file whose first JSONL line is a valid `{ type: "session", id: <string> }` record wins — its `id` is returned.
+All filesystem and parse errors are silently skipped so the helper never throws.
+
+The directory-name is *not* used to derive the session ID — only the JSONL header's `id` field is, because directory naming is not part of Pi's SDK contract while the `SessionHeader` shape is.
 
 ### Deferred: tintinweb in-process case
 

--- a/docs/plans/0143-session-dir-fallback.md
+++ b/docs/plans/0143-session-dir-fallback.md
@@ -1,0 +1,130 @@
+---
+issue: 143
+issue_title: "Parent-session resolution still single-keyed after #96 — `ask` still silently denies in nicobailon/pi-subagents children"
+---
+
+# Session-directory fallback for parent-session resolution
+
+## Problem Statement
+
+After #96, detection of a subagent execution context is broadened — `SUBAGENT_ENV_HINT_KEYS` recognises env vars set by `pi-agent-router`, `nicobailon/pi-subagents`, and `HazAT/pi-interactive-subagents`.
+The resolution side — which parent session the forwarded permission request should be written to — remains env-var-only.
+`resolvePermissionForwardingTargetSessionId()` iterates `SUBAGENT_PARENT_SESSION_ENV_CANDIDATES` and returns the first hit; if none is set, forwarding fails and any `ask`-state permission in a headless child silently denies.
+
+After commit `3829195` (issue #143 first round) the candidates list contains `PI_AGENT_ROUTER_PARENT_SESSION_ID` and `PI_SUBAGENT_PARENT_SESSION`.
+The original CLI extensions covered by `SUBAGENT_ENV_HINT_KEYS` (`nicobailon/pi-subagents`, `HazAT/pi-interactive-subagents`) do not yet set `PI_SUBAGENT_PARENT_SESSION` in spawned children, so the resolution side still misses for the very extensions whose env vars detection now recognises.
+
+Step 2 of the original #96 proposal already named this gap: fall back to the session directory layout when no env candidate resolves.
+Pi's session-directory convention already encodes the parent-child relationship deterministically (verified in `node_modules/@earendil-works/pi-coding-agent/dist/core/session-manager.d.ts:189` and in `nicobailon/pi-subagents/src/extension/index.ts:66 getSubagentSessionRoot`):
+
+```text
+<sessionsDir>/                                ← e.g. ~/.pi/agent/sessions/<cwd-encoded>/
+  <parent-baseName>.jsonl                     ← parent session log; header { type: "session", id: <parentSessionId> }
+  <parent-baseName>/                          ← derived from parent file (basename minus .jsonl)
+    <runId>/                                  ← e.g. "c6825838"
+      run-N/                                  ← attempt index
+        session.jsonl                         ← child's session log
+```
+
+Reading the first JSONL line of `<parent-baseName>.jsonl` yields a `SessionHeader` whose `id` field is the canonical parent session ID.
+This is the same record that pi-coding-agent writes when creating a session.
+
+## Goals
+
+- When env-var resolution misses, walk up the current process's session directory to find an ancestor whose name matches a sibling `<name>.jsonl` session file, read that file's first line, and return its `id` as the parent session ID.
+- Keep env-var resolution as the fast path with strict precedence — adding the fallback must not change behaviour for any setup where an env candidate is set.
+- Make the new helper an isolated, pure module so unit tests can use tmp-dir fixtures.
+- Update the "target session could not be resolved" diagnostic so a user reading the log knows both resolution paths were tried.
+
+## Non-Goals
+
+- Adopting env-var conventions in upstream subagent extensions — orthogonal and explicitly deferred per the #143 follow-up comment.
+- Supporting in-process subagent extensions (`tintinweb/pi-subagents`) — tracked separately in #29; those have no session directory of their own.
+- Walking sibling session directories or maintaining a parent-child registry — the directory layout is enough.
+- Changing the `SessionHeader` parsing surface or relying on additional SDK methods beyond `ctx.sessionManager.getSessionDir()`.
+- Schema, config, or per-agent override changes — none of those touch resolution.
+
+## Background
+
+### Existing flow
+
+`forwarded-permissions/polling.ts::waitForForwardedPermissionApproval` calls `resolvePermissionForwardingTargetSessionId({ hasUI, isSubagent, currentSessionId, env })`.
+When the function returns `null` the child immediately logs a `permission_forwarding.error` event and denies.
+
+### Why filesystem is sufficient
+
+The child's `sessionManager.getSessionDir()` is exposed by Pi's `ReadonlySessionManager` interface (`session-manager.d.ts:189`) and is already consumed in `subagent-context.ts::isSubagentExecutionContext` for the detection path.
+The nesting `<parent-baseName>/<runId>/run-N` is enforced by `nicobailon/pi-subagents` because its `getSubagentSessionRoot()` derives the root from the parent session file's directory and basename — every CLI-spawned child that uses Pi's session manager lives under this layout.
+
+### Why parse the JSONL header
+
+A directory's basename has the form `<timestamp>_<sessionId>`, but the timestamp prefix is not part of the SDK contract.
+The `SessionHeader.id` field is the canonical session identifier and is written by `SessionManager` on session creation.
+Parsing the first line of `<name>.jsonl` is therefore the durable extraction — directory-name parsing would couple the extension to an internal pi convention.
+
+### Bounded walk
+
+`nicobailon/pi-subagents` caps subagent nesting depth in practice (its `PI_SUBAGENT_DEPTH` env var bounds recursion).
+A bounded walk-up (max 8 levels) is enough to traverse from any nested run-N directory to the outermost parent session directory without scanning the entire filesystem.
+
+## Implementation
+
+### New module `src/parent-session-discovery.ts`
+
+Exports a single function:
+
+```typescript
+export function resolveParentSessionIdFromSessionDir(
+  sessionDir: string | null | undefined,
+): string | null;
+```
+
+Algorithm:
+
+1. Return `null` for empty, non-string, or filesystem-root input.
+2. From `sessionDir`, climb at most 8 directory levels.
+3. At each level, check whether `<current>.jsonl` exists as a sibling file.
+4. If it exists, read its first line, parse as JSON, and return the `id` field when `type === "session"` and `id` is a non-empty string.
+5. Any IO error, JSON error, missing `type`, or empty `id` causes the level to be skipped (no exception escapes); on no-match return `null`.
+
+### Modify `src/permission-forwarding.ts::resolvePermissionForwardingTargetSessionId`
+
+- Add an optional `sessionDir?: string | null` field to the options bag.
+- After the env-candidate loop fails, call `resolveParentSessionIdFromSessionDir(options.sessionDir)` and return its result.
+- Env candidates retain first-match precedence; the session-directory fallback runs only when every candidate is empty or `"unknown"`.
+
+### Modify `src/forwarded-permissions/polling.ts::waitForForwardedPermissionApproval`
+
+- Pass `sessionDir: ctx.sessionManager.getSessionDir()` into the options bag.
+- Update the `permission_forwarding.error` log message to state that the session-directory fallback was also tried, so the diagnostic remains accurate when both paths miss.
+
+### Documentation
+
+Extend `docs/architecture/architecture.md` § "Parent-session resolution" with a sub-section describing the session-directory fallback and its bounded walk.
+
+## Module-Level Changes
+
+| File | Change |
+| --- | --- |
+| `src/parent-session-discovery.ts` | New module |
+| `src/permission-forwarding.ts` | Add `sessionDir` option; chain to new helper after env loop |
+| `src/forwarded-permissions/polling.ts` | Pass `sessionDir` from `ctx.sessionManager`; update error log text |
+| `tests/parent-session-discovery.test.ts` | New file — tmp-dir fixtures for happy path, nested walk-up, malformed JSONL, root reached |
+| `tests/permission-forwarding.test.ts` | New tests for `sessionDir` option (env-precedence, tmp-dir success, undefined no-op) |
+| `docs/architecture/architecture.md` | Document the session-directory fallback |
+| `docs/plans/0143-session-dir-fallback.md` | This plan |
+
+## TDD Steps
+
+1. Plan (this file).
+2. Tests for `resolveParentSessionIdFromSessionDir` (red).
+3. Implement `resolveParentSessionIdFromSessionDir` (green).
+4. Tests for extended `resolvePermissionForwardingTargetSessionId` with `sessionDir` option (red).
+5. Implement the option + `polling.ts` wiring + error-log update (green).
+6. Update architecture doc.
+7. `pnpm run check` (build + lint:all + test) — full suite, not just affected files, because `permission-forwarding.ts` is widely imported.
+
+## Risk and Backout
+
+The session-directory fallback runs only on the path where forwarding currently fails (no env candidate set), so the worst-case outcome compared to today is unchanged behaviour: forwarding still cannot resolve and the same denial path runs.
+Backout is reverting the polling.ts and permission-forwarding.ts edits; the new module stands alone and has no other callers.

--- a/src/forwarded-permissions/polling.ts
+++ b/src/forwarded-permissions/polling.ts
@@ -62,6 +62,17 @@ export function getSessionId(ctx: ExtensionContext): string {
   return "unknown";
 }
 
+function getSessionDir(ctx: ExtensionContext): string | null {
+  try {
+    const sessionDir = ctx.sessionManager.getSessionDir();
+    return typeof sessionDir === "string" && sessionDir.trim()
+      ? sessionDir
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function getContextSystemPrompt(ctx: ExtensionContext): string | undefined {
   const getSystemPrompt = toRecord(ctx).getSystemPrompt;
   if (typeof getSystemPrompt !== "function") {
@@ -101,20 +112,23 @@ export async function waitForForwardedPermissionApproval(
   deps: PermissionForwardingDeps,
 ): Promise<PermissionPromptDecision> {
   const requesterSessionId = getSessionId(ctx);
+  const requesterSessionDir = getSessionDir(ctx);
   const targetSessionId = resolvePermissionForwardingTargetSessionId({
     hasUI: ctx.hasUI,
     isSubagent: isSubagentExecutionContext(ctx, deps.subagentSessionsDir),
     currentSessionId: requesterSessionId,
     env: process.env,
+    sessionDir: requesterSessionDir,
   });
 
   if (!targetSessionId) {
     logPermissionForwardingError(
       deps.logger,
       `Permission forwarding target session could not be resolved. ` +
-        `Checked env vars: ${SUBAGENT_PARENT_SESSION_ENV_CANDIDATES.join(", ")}. ` +
-        `If you are using a subagent extension (nicobailon/pi-subagents, HazAT/pi-interactive-subagents, etc.), ` +
-        `ask its maintainer to set PI_SUBAGENT_PARENT_SESSION in the child process environment ` +
+        `Checked env vars: ${SUBAGENT_PARENT_SESSION_ENV_CANDIDATES.join(", ")}; ` +
+        `the session-directory walk-up from '${requesterSessionDir ?? "<unknown>"}' also found no parent session log. ` +
+        `If you are using a subagent extension (nicobailon/pi-subagents, HazAT/pi-interactive-subagents, etc.) ` +
+        `outside Pi's normal session-directory layout, ask its maintainer to set PI_SUBAGENT_PARENT_SESSION in the child process environment ` +
         `(see https://github.com/gotgenes/pi-permission-system/issues/143).`,
     );
     return { approved: false, state: "denied" };

--- a/src/parent-session-discovery.ts
+++ b/src/parent-session-discovery.ts
@@ -1,0 +1,142 @@
+import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
+import { dirname } from "node:path";
+
+/**
+ * Maximum directory levels to climb when searching for a sibling session log.
+ *
+ * Subagent nesting is depth-bounded in practice (e.g. `nicobailon/pi-subagents`
+ * caps recursion via `PI_SUBAGENT_DEPTH`). Eight levels comfortably covers any
+ * realistic `<parent>/<runId>/run-<n>/session/<runId>/run-<n>` chain.
+ */
+const MAX_WALK_DEPTH = 8;
+
+/**
+ * Cap on bytes read when probing a candidate session log file.
+ *
+ * The session header is the first JSONL line and is ~150 bytes in practice.
+ * Reading 16 KiB is enough to capture any realistic header without loading
+ * a multi-megabyte session log on every permission probe.
+ */
+const HEADER_READ_BUFFER_BYTES = 16 * 1024;
+
+/**
+ * Pi session log header shape — the first line of every session JSONL file.
+ *
+ * Mirrors the relevant subset of `SessionHeader` exported by
+ * `@earendil-works/pi-coding-agent`. Only `type` and `id` are read here.
+ */
+interface SessionHeaderShape {
+  readonly type: unknown;
+  readonly id: unknown;
+}
+
+/**
+ * Resolve a parent session ID from Pi's session-directory layout.
+ *
+ * Pi (and `nicobailon/pi-subagents` via its `getSubagentSessionRoot`) nest
+ * subagent session directories under their parent session file's basename:
+ *
+ *   <sessionsDir>/
+ *     <parentBaseName>.jsonl              ← parent session log; header.id is the parent ID
+ *     <parentBaseName>/
+ *       <runId>/run-<n>/                  ← child session directory
+ *         session.jsonl                   ← child session log
+ *
+ * Climbs up from `sessionDir` up to `MAX_WALK_DEPTH` levels. At each level it
+ * checks whether `<currentDir>.jsonl` exists as a sibling file. The first such
+ * file whose first JSONL line is a valid `{ type: "session", id: <string> }`
+ * record wins — its `id` is returned.
+ *
+ * Returns `null` for any degenerate input or when no matching ancestor is
+ * found. Filesystem and parse errors at intermediate levels are silently
+ * skipped so the function never throws.
+ */
+export function resolveParentSessionIdFromSessionDir(
+  sessionDir: string | null | undefined,
+): string | null {
+  if (typeof sessionDir !== "string") {
+    return null;
+  }
+  const trimmed = sessionDir.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  let current = trimmed;
+  for (let depth = 0; depth < MAX_WALK_DEPTH; depth++) {
+    const parent = dirname(current);
+    if (parent === current) {
+      // Reached filesystem root.
+      return null;
+    }
+    const candidateLog = `${current}.jsonl`;
+    const parsed = tryReadSessionId(candidateLog);
+    if (parsed !== null) {
+      return parsed;
+    }
+    current = parent;
+  }
+  return null;
+}
+
+function tryReadSessionId(candidateLog: string): string | null {
+  if (!existsSync(candidateLog)) {
+    return null;
+  }
+  let fd: number;
+  try {
+    // Reject directories and non-regular files before opening.
+    if (!statSync(candidateLog).isFile()) {
+      return null;
+    }
+    fd = openSync(candidateLog, "r");
+  } catch {
+    return null;
+  }
+
+  let firstLine: string;
+  try {
+    const buffer = Buffer.alloc(HEADER_READ_BUFFER_BYTES);
+    const bytesRead = readSync(fd, buffer, 0, HEADER_READ_BUFFER_BYTES, 0);
+    if (bytesRead <= 0) {
+      return null;
+    }
+    const chunk = buffer.toString("utf-8", 0, bytesRead);
+    const newlineIndex = chunk.indexOf("\n");
+    firstLine = newlineIndex === -1 ? chunk : chunk.slice(0, newlineIndex);
+    if (!firstLine) {
+      return null;
+    }
+  } catch {
+    return null;
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      // Best-effort close — the read result is already captured.
+    }
+  }
+
+  return parseSessionHeaderId(firstLine);
+}
+
+function parseSessionHeaderId(line: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    return null;
+  }
+  const header = parsed as SessionHeaderShape;
+  if (header.type !== "session") {
+    return null;
+  }
+  if (typeof header.id !== "string") {
+    return null;
+  }
+  const trimmedId = header.id.trim();
+  return trimmedId ? trimmedId : null;
+}

--- a/src/permission-forwarding.ts
+++ b/src/permission-forwarding.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { resolveParentSessionIdFromSessionDir } from "./parent-session-discovery";
 import type { PermissionDecisionState } from "./permission-dialog";
 
 export const PERMISSION_FORWARDING_POLL_INTERVAL_MS = 250;
@@ -118,6 +119,13 @@ export function resolvePermissionForwardingTargetSessionId(options: {
   isSubagent: boolean;
   currentSessionId?: string | null;
   env?: NodeJS.ProcessEnv;
+  /**
+   * Current process's session directory (e.g. `ctx.sessionManager.getSessionDir()`).
+   * When the env-candidate loop misses, the resolver walks ancestors of this
+   * directory looking for a sibling `<name>.jsonl` whose JSONL header carries
+   * the parent session ID.
+   */
+  sessionDir?: string | null;
 }): string | null {
   if (options.hasUI) {
     return normalizePermissionForwardingSessionId(options.currentSessionId);
@@ -132,7 +140,8 @@ export function resolvePermissionForwardingTargetSessionId(options: {
     const resolved = normalizePermissionForwardingSessionId(env[key]);
     if (resolved) return resolved;
   }
-  return null;
+
+  return resolveParentSessionIdFromSessionDir(options.sessionDir);
 }
 
 export function isForwardedPermissionRequestForSession(

--- a/tests/parent-session-discovery.test.ts
+++ b/tests/parent-session-discovery.test.ts
@@ -1,0 +1,289 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { resolveParentSessionIdFromSessionDir } from "../src/parent-session-discovery";
+
+const SESSION_HEADER_JSON = JSON.stringify({
+  type: "session",
+  version: 3,
+  id: "019e1786-8469-743c-8960-3a86d222fcb3",
+  timestamp: "2026-05-11T14:52:32.234Z",
+  cwd: "/home/me/proj",
+});
+
+const ENTRY_LINE_JSON = JSON.stringify({
+  type: "model_change",
+  id: "196c6bc5",
+  parentId: null,
+  timestamp: "2026-05-11T14:52:33.000Z",
+  provider: "deepseek",
+  modelId: "deepseek-v4-pro",
+});
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "pi-permission-system-parent-discovery-"));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+/**
+ * Lay out a Pi session-directory tree mirroring nicobailon/pi-subagents:
+ *
+ *   <root>/
+ *     <parentName>.jsonl              ← parent session log with given header
+ *     <parentName>/
+ *       <runId>/
+ *         run-<attempt>/              ← child session dir (returned)
+ *           session.jsonl             ← child session log (created if `withChildHeader`)
+ */
+function layoutChild(opts: {
+  root: string;
+  parentName: string;
+  parentHeaderJson?: string | null;
+  runId?: string;
+  attempt?: number;
+  withChildHeader?: boolean;
+}): string {
+  const runId = opts.runId ?? "c6825838";
+  const attempt = opts.attempt ?? 0;
+  const childDir = join(opts.root, opts.parentName, runId, `run-${attempt}`);
+  mkdirSync(childDir, { recursive: true });
+  if (opts.parentHeaderJson !== null) {
+    writeFileSync(
+      join(opts.root, `${opts.parentName}.jsonl`),
+      `${opts.parentHeaderJson ?? SESSION_HEADER_JSON}\n${ENTRY_LINE_JSON}\n`,
+      "utf-8",
+    );
+  }
+  if (opts.withChildHeader !== false) {
+    writeFileSync(
+      join(childDir, "session.jsonl"),
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "019e1ae2-ff6d-748c-8205-9850d77d49cd",
+        timestamp: "2026-05-12T06:32:24.685Z",
+        cwd: "/home/me/proj",
+      })}\n`,
+      "utf-8",
+    );
+  }
+  return childDir;
+}
+
+describe("resolveParentSessionIdFromSessionDir — degenerate input", () => {
+  test("returns null for null", () => {
+    expect(resolveParentSessionIdFromSessionDir(null)).toBeNull();
+  });
+
+  test("returns null for undefined", () => {
+    expect(resolveParentSessionIdFromSessionDir(undefined)).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(resolveParentSessionIdFromSessionDir("")).toBeNull();
+  });
+
+  test("returns null for whitespace-only string", () => {
+    expect(resolveParentSessionIdFromSessionDir("   ")).toBeNull();
+  });
+});
+
+describe("resolveParentSessionIdFromSessionDir — happy path", () => {
+  test("resolves parent ID from sibling .jsonl one level up from run-N", () => {
+    const childDir = layoutChild({
+      root: workDir,
+      parentName: "2026-05-11T14-52-32-234Z_019e1786-8469-743c-8960-3a86d222fcb3",
+    });
+    expect(resolveParentSessionIdFromSessionDir(childDir)).toBe(
+      "019e1786-8469-743c-8960-3a86d222fcb3",
+    );
+  });
+
+  test("returns the session id from the JSONL header, not the directory basename", () => {
+    // Directory name has a deliberately different ID from the header.id.
+    // Discovery must honor the header — directory naming is not part of the SDK contract.
+    const childDir = layoutChild({
+      root: workDir,
+      parentName: "2026-05-11T14-52-32-234Z_NOT-THE-REAL-SESSION-ID",
+      parentHeaderJson: JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "real-parent-session-id-from-header",
+        timestamp: "2026-05-11T14:52:32.234Z",
+        cwd: "/home/me/proj",
+      }),
+    });
+    expect(resolveParentSessionIdFromSessionDir(childDir)).toBe(
+      "real-parent-session-id-from-header",
+    );
+  });
+});
+
+describe("resolveParentSessionIdFromSessionDir — nested grandchild", () => {
+  test("walks past intermediate directories that have no sibling .jsonl", () => {
+    // Grandchild layout: <outer>.jsonl exists; <outer>/<runA>/run-0/session/<runB>/run-0 is the grandchild dir.
+    // No sibling .jsonl exists for the intermediate <runA>, run-0, session, or <runB> directories.
+    const outer = "2026-05-11T14-52-32-234Z_outer-parent-id";
+    const innerName = "session"; // basename of the nested "session.jsonl"
+    const grandchild = join(
+      workDir,
+      outer,
+      "runA",
+      "run-0",
+      innerName,
+      "runB",
+      "run-0",
+    );
+    mkdirSync(grandchild, { recursive: true });
+    writeFileSync(
+      join(workDir, `${outer}.jsonl`),
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "outer-parent-id",
+        timestamp: "2026-05-11T14:52:32.234Z",
+        cwd: "/home/me/proj",
+      })}\n`,
+      "utf-8",
+    );
+    // Intermediate "session.jsonl" simulates the immediate parent (a subagent that itself spawned).
+    writeFileSync(
+      join(workDir, outer, "runA", "run-0", "session.jsonl"),
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "immediate-parent-id",
+        timestamp: "2026-05-12T06:00:00.000Z",
+        cwd: "/home/me/proj",
+      })}\n`,
+      "utf-8",
+    );
+    // Closest sibling .jsonl wins — immediate parent, not the outermost.
+    expect(resolveParentSessionIdFromSessionDir(grandchild)).toBe(
+      "immediate-parent-id",
+    );
+  });
+});
+
+describe("resolveParentSessionIdFromSessionDir — no match", () => {
+  test("returns null when no sibling .jsonl exists at any ancestor", () => {
+    const childDir = join(workDir, "no-parent", "runX", "run-0");
+    mkdirSync(childDir, { recursive: true });
+    expect(resolveParentSessionIdFromSessionDir(childDir)).toBeNull();
+  });
+
+  test("returns null when sessionDir does not exist", () => {
+    expect(
+      resolveParentSessionIdFromSessionDir(join(workDir, "does-not-exist")),
+    ).toBeNull();
+  });
+});
+
+describe("resolveParentSessionIdFromSessionDir — malformed sibling", () => {
+  test("returns null when sibling .jsonl is empty", () => {
+    const parentName = "empty-parent";
+    const childDir = join(workDir, parentName, "run-x", "run-0");
+    mkdirSync(childDir, { recursive: true });
+    writeFileSync(join(workDir, `${parentName}.jsonl`), "", "utf-8");
+    expect(resolveParentSessionIdFromSessionDir(childDir)).toBeNull();
+  });
+
+  test("returns null when first line is not valid JSON", () => {
+    const childDir = layoutChild({
+      root: workDir,
+      parentName: "bad-json",
+      parentHeaderJson: "{this is not json",
+    });
+    expect(resolveParentSessionIdFromSessionDir(childDir)).toBeNull();
+  });
+
+  test("returns null when header is missing the type field", () => {
+    const childDir = layoutChild({
+      root: workDir,
+      parentName: "no-type",
+      parentHeaderJson: JSON.stringify({ id: "some-id", version: 3 }),
+    });
+    expect(resolveParentSessionIdFromSessionDir(childDir)).toBeNull();
+  });
+
+  test("returns null when header type is not 'session'", () => {
+    const childDir = layoutChild({
+      root: workDir,
+      parentName: "wrong-type",
+      parentHeaderJson: JSON.stringify({
+        type: "message",
+        id: "some-id",
+      }),
+    });
+    expect(resolveParentSessionIdFromSessionDir(childDir)).toBeNull();
+  });
+
+  test("returns null when header id is missing", () => {
+    const childDir = layoutChild({
+      root: workDir,
+      parentName: "no-id",
+      parentHeaderJson: JSON.stringify({ type: "session", version: 3 }),
+    });
+    expect(resolveParentSessionIdFromSessionDir(childDir)).toBeNull();
+  });
+
+  test("returns null when header id is empty string", () => {
+    const childDir = layoutChild({
+      root: workDir,
+      parentName: "empty-id",
+      parentHeaderJson: JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "",
+      }),
+    });
+    expect(resolveParentSessionIdFromSessionDir(childDir)).toBeNull();
+  });
+
+  test("skips a non-session .jsonl ancestor and continues climbing", () => {
+    // Outer ancestor IS a valid session log; immediate ancestor's sibling .jsonl
+    // exists but its header is not a session header. Climbing must continue.
+    const outer = "outer-parent";
+    const intermediate = "intermediate";
+    const grandchild = join(workDir, outer, intermediate, "runId", "run-0");
+    mkdirSync(grandchild, { recursive: true });
+    writeFileSync(
+      join(workDir, `${outer}.jsonl`),
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "outer-id",
+        timestamp: "2026-05-11T14:52:32.234Z",
+        cwd: "/home/me/proj",
+      })}\n`,
+      "utf-8",
+    );
+    writeFileSync(
+      join(workDir, outer, `${intermediate}.jsonl`),
+      `${JSON.stringify({ type: "message", id: "msg-id" })}\n`,
+      "utf-8",
+    );
+    expect(resolveParentSessionIdFromSessionDir(grandchild)).toBe("outer-id");
+  });
+});
+
+describe("resolveParentSessionIdFromSessionDir — bounded walk", () => {
+  test("returns null when the walk exceeds the depth limit before finding a sibling", () => {
+    // Build a chain of 12 nested empty directories with no sibling .jsonl
+    // anywhere — the bounded walk must give up and return null without scanning to fs root.
+    let dir = workDir;
+    for (let i = 0; i < 12; i++) {
+      dir = join(dir, `level-${i}`);
+    }
+    mkdirSync(dir, { recursive: true });
+    expect(resolveParentSessionIdFromSessionDir(dir)).toBeNull();
+  });
+});

--- a/tests/permission-forwarding.test.ts
+++ b/tests/permission-forwarding.test.ts
@@ -1,4 +1,8 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   resolvePermissionForwardingTargetSessionId,
   SUBAGENT_PARENT_SESSION_ENV_CANDIDATES,
@@ -8,6 +12,24 @@ import {
 afterEach(() => {
   vi.unstubAllEnvs();
 });
+
+function layoutParentChild(root: string, parentId: string): string {
+  const parentName = `2026-05-11T14-52-32-234Z_${parentId}`;
+  const childDir = join(root, parentName, "runId", "run-0");
+  mkdirSync(childDir, { recursive: true });
+  writeFileSync(
+    join(root, `${parentName}.jsonl`),
+    `${JSON.stringify({
+      type: "session",
+      version: 3,
+      id: parentId,
+      timestamp: "2026-05-11T14:52:32.234Z",
+      cwd: "/home/me/proj",
+    })}\n`,
+    "utf-8",
+  );
+  return childDir;
+}
 
 describe("SUBAGENT_PARENT_SESSION_ENV_CANDIDATES", () => {
   test("is an array containing PI_AGENT_ROUTER_PARENT_SESSION_ID", () => {
@@ -143,5 +165,108 @@ describe("resolvePermissionForwardingTargetSessionId", () => {
         isSubagent: true,
       }),
     ).toBe("env-session-abc");
+  });
+});
+
+describe("resolvePermissionForwardingTargetSessionId — sessionDir fallback", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(
+      join(tmpdir(), "pi-permission-system-forwarding-sessiondir-"),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("resolves parent ID from session directory when no env candidate is set", () => {
+    const childDir = layoutParentChild(workDir, "parent-from-disk");
+    expect(
+      resolvePermissionForwardingTargetSessionId({
+        hasUI: false,
+        isSubagent: true,
+        currentSessionId: "child-session-id",
+        env: {},
+        sessionDir: childDir,
+      }),
+    ).toBe("parent-from-disk");
+  });
+
+  test("env candidate takes precedence over sessionDir", () => {
+    const childDir = layoutParentChild(workDir, "parent-from-disk");
+    expect(
+      resolvePermissionForwardingTargetSessionId({
+        hasUI: false,
+        isSubagent: true,
+        currentSessionId: "child-session-id",
+        env: { PI_AGENT_ROUTER_PARENT_SESSION_ID: "parent-from-env" },
+        sessionDir: childDir,
+      }),
+    ).toBe("parent-from-env");
+  });
+
+  test("sessionDir is ignored when isSubagent=false", () => {
+    const childDir = layoutParentChild(workDir, "parent-from-disk");
+    expect(
+      resolvePermissionForwardingTargetSessionId({
+        hasUI: false,
+        isSubagent: false,
+        currentSessionId: "current-session",
+        env: {},
+        sessionDir: childDir,
+      }),
+    ).toBeNull();
+  });
+
+  test("sessionDir is ignored when hasUI=true (UI host owns forwarding)", () => {
+    const childDir = layoutParentChild(workDir, "parent-from-disk");
+    expect(
+      resolvePermissionForwardingTargetSessionId({
+        hasUI: true,
+        isSubagent: true,
+        currentSessionId: "ui-session",
+        env: {},
+        sessionDir: childDir,
+      }),
+    ).toBe("ui-session");
+  });
+
+  test("sessionDir undefined falls back to env-only behaviour", () => {
+    expect(
+      resolvePermissionForwardingTargetSessionId({
+        hasUI: false,
+        isSubagent: true,
+        currentSessionId: "child-session-id",
+        env: {},
+      }),
+    ).toBeNull();
+  });
+
+  test("sessionDir null is treated the same as undefined", () => {
+    expect(
+      resolvePermissionForwardingTargetSessionId({
+        hasUI: false,
+        isSubagent: true,
+        currentSessionId: "child-session-id",
+        env: {},
+        sessionDir: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("sessionDir without a matching ancestor returns null", () => {
+    const orphanDir = join(workDir, "no-parent", "runId", "run-0");
+    mkdirSync(orphanDir, { recursive: true });
+    expect(
+      resolvePermissionForwardingTargetSessionId({
+        hasUI: false,
+        isSubagent: true,
+        currentSessionId: "child-session-id",
+        env: {},
+        sessionDir: orphanDir,
+      }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
Closes gotgenes/pi-packages#22.

## Summary

Adds a session-directory fallback to `resolvePermissionForwardingTargetSessionId()`.
When every env candidate in `SUBAGENT_PARENT_SESSION_ENV_CANDIDATES` misses, the resolver now climbs the current process's session directory looking for a sibling `<name>.jsonl` whose JSONL header is a valid `{ type: "session", id: <string> }` record — and returns that `id` as the parent session.

This closes the resolution side of gotgenes/pi-packages#44 step 2 without requiring `nicobailon/pi-subagents`, `HazAT/pi-interactive-subagents`, or any future CLI-based subagent extension to set `PI_SUBAGENT_PARENT_SESSION` in spawned children.
Env-var resolution retains first-match precedence; the filesystem walk is strictly a fallback.

See [`docs/plans/0143-session-dir-fallback.md`](./docs/plans/0143-session-dir-fallback.md) for the full rationale, including the verified layout used by `nicobailon/pi-subagents::getSubagentSessionRoot`.

## Why this is filesystem-only

Pi's session-directory layout already encodes the parent-child relationship for CLI-spawned subagents:

```text
<sessionsDir>/
  <parentBaseName>.jsonl              ← parent log; header.id is the parent ID
  <parentBaseName>/
    <runId>/run-<n>/                  ← child session directory (ctx.sessionManager.getSessionDir())
      session.jsonl                   ← child log
```

The helper reads `header.id` from the JSONL — not the directory basename — because the header shape is part of the Pi SDK contract (`SessionHeader` in `@earendil-works/pi-coding-agent`) while directory naming is not.

## Behavior changes

| Scenario | Before | After |
| --- | --- | --- |
| Env candidate set | resolves via env | unchanged — env still wins |
| Env candidate empty, in CLI subagent with normal layout | returns null → silent deny | resolves parent ID via directory walk |
| Env candidate empty, no session-dir layout (in-process, tintinweb) | returns null → silent deny | unchanged — still null (deferred to gotgenes/pi-permission-system#29) |
| UI host | returns current session ID | unchanged |
| Non-subagent | returns null | unchanged |

The diagnostic emitted on resolution miss now states that both env vars and the session-directory walk-up were attempted, so the log accurately reflects what was tried.

## Implementation

| File | Change |
| --- | --- |
| `src/parent-session-discovery.ts` | New helper `resolveParentSessionIdFromSessionDir(sessionDir)` — bounded 8-level walk, 16 KiB header read, all errors silently skipped |
| `src/permission-forwarding.ts` | New `sessionDir?` option on `resolvePermissionForwardingTargetSessionId`; chains to the helper after the env loop |
| `src/forwarded-permissions/polling.ts` | Pass `ctx.sessionManager.getSessionDir()` (defended against throw); update the `permission_forwarding.error` log text |
| `docs/architecture/architecture.md` | Document the fallback under § "Parent-session resolution" |
| `docs/plans/0143-session-dir-fallback.md` | Plan |

## Testing

- **24 new tests** (17 for the helper, 7 for the resolver integration). Tmp-dir fixtures mirror the real layout.
- Coverage: happy path, depth-N walk-up, nested grandchild, no sibling, missing dir, malformed JSON, missing `type`, wrong `type`, missing `id`, empty `id`, non-session ancestor skipping continues walk, bounded-depth termination, env-precedence, `sessionDir` ignored when `isSubagent=false` or `hasUI=true`, null/undefined `sessionDir`, no ancestor match.
- Full suite: 1,392 / 1,392 passing.
- `pnpm run build` (tsc): clean.
- `pnpm run lint:md`: clean across all 145 docs.
- `pnpm run lint:imports`: clean.

> [!NOTE]
> Biome (`pnpm run lint`) was **not** run locally — the `@biomejs/cli-linux-x64` binary won't execute on NixOS without a wrapped dynamic linker.
> Edits follow the surrounding code's biome-formatted style; please flag if CI surfaces anything.

## Backout

Worst case for the fallback is the existing behaviour (forwarding still cannot resolve → same denial path).
Reverting the polling.ts and permission-forwarding.ts edits is sufficient; the new module stands alone.
